### PR TITLE
Adding compatability for Midnight

### DIFF
--- a/BlizzardBars_Mouseover.toc
+++ b/BlizzardBars_Mouseover.toc
@@ -1,4 +1,4 @@
-## Interface: 110200, 110205
+## Interface: 110205, 110207, 120000
 
 ## Title: BlizzardBars_Mouseover
 ## Notes: Hides the default Blizzard bars, shows them on mouseover.

--- a/Config.lua
+++ b/Config.lua
@@ -60,7 +60,8 @@ addon.settings = {
 			end,
 			SetValue = function(value)
 				addon.db.MainMenuBar = value
-				addon:ApplyOnBar(addon.bars["MainMenuBar"], "MainMenuBar")
+				local barName = (WOW_PROJECT_ID == WOW_PROJECT_MAINLINE) and (select(4, GetBuildInfo()) >= 120000) and "MainActionBar" or "MainMenuBar" -- Midnight compatability. See Main.lua changes.
+				addon:ApplyOnBar(addon.bars[barName], barName)
 			end,
 		},
 		{

--- a/Main.lua
+++ b/Main.lua
@@ -29,7 +29,10 @@ local Settings_OpenToCategory = Settings.OpenToCategory
 
 -- Constants
 -----------------------------------------------------------
-local MAIN_BAR = "MainMenuBar"
+-- Detect Midnight (12.x) vs TWW (11.x), Most of this can be removed once Midnight pre-patch is live.
+local IS_MIDNIGHT = (WOW_PROJECT_ID == WOW_PROJECT_MAINLINE) and (select(4, GetBuildInfo()) >= 120000)
+
+local MAIN_BAR = IS_MIDNIGHT and "MainActionBar" or "MainMenuBar" -- Midnight renamed MainMenuBar to MainActionBar.
 addon.MAIN_BAR = MAIN_BAR
 local PET_BAR = "PetActionBar"
 addon.PET_BAR = PET_BAR


### PR DESCRIPTION
MainMenuBar is renamed MainActionBar with the WoW 12.0+ API

Closes #8 